### PR TITLE
Add HTTP support on port 80

### DIFF
--- a/src-tauri/bundle/templates/docker-compose.yml.template
+++ b/src-tauri/bundle/templates/docker-compose.yml.template
@@ -6,6 +6,7 @@ services:
     image: nginx:1.23.2-alpine
     ports:
       - 443:443
+      - 80:80
     extra_hosts:
     - "host.docker.internal:host-gateway"
     volumes:

--- a/src-tauri/bundle/templates/server.conf.template
+++ b/src-tauri/bundle/templates/server.conf.template
@@ -8,6 +8,8 @@ server {
 
     listen 443 ssl;
     listen [::]:443 ssl;
+    listen 80;
+    listen [::]:80;
 
     # cert path
     ssl_certificate /usr/local/ssl/cert/{DOMAIN_NAME}/cert.pem;


### PR DESCRIPTION
Modify the Nginx configuration to support HTTP on port 80 without redirecting to HTTPS.

* Add `listen 80;` and `listen [::]:80;` to the `server` block in `src-tauri/bundle/templates/server.conf.template`.
* Update `src-tauri/bundle/templates/docker-compose.yml.template` to map port 80 for the Nginx service.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YEK-PLUS/ophiuchi-desktop/pull/1?shareId=de1a7644-3b58-405b-af64-80dd66159607).